### PR TITLE
Make `checker-qual` dependency explicit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,17 @@ configurations {
     requireJavadoc
 }
 
+ext {
+    eisopVersion = '3.49.1-eisop1'
+}
+
 dependencies {
-    implementation 'io.github.eisop:checker:3.49.1-eisop1'
+    implementation "io.github.eisop:checker:$eisopVersion"
+    implementation "io.github.eisop:checker-qual:$eisopVersion"
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0'
     implementation 'com.google.code.gson:gson:2.12.1'
     implementation 'commons-cli:commons-cli:1.9.0'
-    implementation 'com.google.guava:guava:33.4.0-jre'
+    implementation 'com.google.guava:guava:33.4.5-jre'
     testImplementation 'junit:junit:4.13.2'
 
     if (JavaVersion.current() >= JavaVersion.VERSION_17) {


### PR DESCRIPTION
Bump com.google.guava:guava from 33.4.0-jre to 33.4.5-jre #308 fails with:

````
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler output below.
  /home/runner/.gradle/caches/modules-2/files-2.1/io.github.eisop/checker/3.49.1-eisop1/c5df3a63bc4b41a660e0b69fef2c6142becccc77/checker-3.49.1-eisop1.jar(/org/checkerframework/framework/util/CheckerMain.class): warning: Cannot find annotation method 'value()' in type 'Regex': class file for org.checkerframework.checker.regex.qual.Regex not found

  1 error
  1 warning
````

It looks like we used the `checker-qual` dependency from guava instead of using our own.